### PR TITLE
Migrate to swift4.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 NotificationObserverHelper
+Copyright (c) 2019 NotificationObserverHelper
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NotificationObserverHelper.podspec
+++ b/NotificationObserverHelper.podspec
@@ -1,13 +1,12 @@
 
 Pod::Spec.new do |s|
 s.name = 'NotificationObserverHelper'
-s.version = '1.1'
+s.version = '1.2'
 s.ios.deployment_target  = '10.0'
 s.source        = { :git => 'https://github.com/srpoucse/Notification-Observer-Helper.git', :tag => "#{s.version}"}
 s.homepage      = 'https://github.com/srpoucse/Notification-Observer-Helper.git'
 s.summary       =  'iOS Notification Observer Helper Utility'
 s.license       = { :type => 'MIT', :file => 'LICENSE'}
 s.authors       =  { 'RATNA PAUL SAKA' => 'pauljason89442@gmail.com' }
-s.source_files  = 'NotificationObserverHelper/**/*.{swift}'
-s.resources     = 'NotificationObserverHelper/**/*.{storyboard,xib,xcassets}'
+s.source_files  = 'NotificationObserverHelper/NotificationObserverHelper.swift'
 end

--- a/NotificationObserverHelper.xcodeproj/project.pbxproj
+++ b/NotificationObserverHelper.xcodeproj/project.pbxproj
@@ -145,19 +145,19 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = srp;
 				TargetAttributes = {
 					56DE4E7E1E8AC532006BB4D4 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = UE22YNAKHW;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 					56DE4E921E8AC532006BB4D4 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = UE22YNAKHW;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 56DE4E7E1E8AC532006BB4D4;
 					};
@@ -261,15 +261,23 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -311,15 +319,23 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -354,7 +370,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = srp.NotificationObserverHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -367,7 +384,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = srp.NotificationObserverHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -381,7 +399,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = srp.NotificationObserverHelperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NotificationObserverHelper.app/NotificationObserverHelper";
 			};
 			name = Debug;
@@ -396,7 +415,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = srp.NotificationObserverHelperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NotificationObserverHelper.app/NotificationObserverHelper";
 			};
 			name = Release;

--- a/NotificationObserverHelper.xcodeproj/xcuserdata/rsaka.xcuserdatad/xcschemes/NotificationObserverHelper.xcscheme
+++ b/NotificationObserverHelper.xcodeproj/xcuserdata/rsaka.xcuserdatad/xcschemes/NotificationObserverHelper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/NotificationObserverHelper/AppDelegate.swift
+++ b/NotificationObserverHelper/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/NotificationObserverHelper/Info.plist
+++ b/NotificationObserverHelper/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/NotificationObserverHelper/NotificationObserverHelper.swift
+++ b/NotificationObserverHelper/NotificationObserverHelper.swift
@@ -31,12 +31,12 @@ extension NotificationCenter {
     }
 }
 
-class NotificationObserver : NSObject {
+public class NotificationObserver : NSObject {
     let name : Notification.Name
     let handler : (Notification)->(Swift.Void)
     let notificationCenter : NotificationCenter
     fileprivate var observer : NSObjectProtocol
-    required init(_ notificationCenter: NotificationCenter = NotificationCenter.default, name : Notification.Name, handler: @escaping (Notification)->(Swift.Void)) {
+    required public init(_ notificationCenter: NotificationCenter = NotificationCenter.default, name : Notification.Name, handler: @escaping (Notification)->(Swift.Void)) {
         self.notificationCenter = notificationCenter
         self.name = name
         self.handler = handler

--- a/NotificationObserverHelper/ViewController.swift
+++ b/NotificationObserverHelper/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        keyboardObserver = NotificationObserver(name: Notification.Name.UIKeyboardDidShow, handler: { (note) -> (Void) in
+        keyboardObserver = NotificationObserver(name: UIResponder.keyboardDidShowNotification, handler: { (note) -> (Void) in
             print("Did Show Keyboard")
         })
         
@@ -39,7 +39,7 @@ class ViewController: UIViewController {
         timer = Timer.scheduledTimer(timeInterval: 10, target: self, selector: #selector(deleteObserver), userInfo: nil, repeats: false)
     }
 
-    func deleteObserver() {
+    @objc func deleteObserver() {
         self.keyboardObserver = nil
         timer?.invalidate()
     }


### PR DESCRIPTION
Migrate to swift 4.2
Apply recommended Xcode build settings.
Make class and constructor public.
Update the podspec source file to have the utility class only.